### PR TITLE
opensuse: Add `awk` to OpenSUSE

### DIFF
--- a/Dockerfile-opensuse-ci-c
+++ b/Dockerfile-opensuse-ci-c
@@ -20,3 +20,4 @@ RUN zypper -n install bzip2 gzip tar unzip xz zip
 RUN zypper -n install git
 RUN zypper -n install autoconf automake gcc gcc-c++ libtool m4 make
 RUN zypper -n install findutils
+RUN zypper -n install awk


### PR DESCRIPTION
Tumbleweed image stopped having `awk` installed for some reason, fixing that here.